### PR TITLE
Fix class variable access

### DIFF
--- a/libraries/honeycomb.rb
+++ b/libraries/honeycomb.rb
@@ -1,50 +1,70 @@
 require "chef/http/simple_json"
 require "time"
 
-VERSION="0.1.0"
+VERSION="0.1.1"
 
 class Honeycomb
-  @@num_resources_modified = 0
-  def self.converge_start
-    @@converge_start = Time.now
-  end
-  def self.converge_complete
-    @@converge_duration = Time.now - @@converge_start
-  end
-  def self.handlers_start
-    @@handlers_start = Time.now
-  end
-  def self.handlers_completed
-    @@handlers_duration = Time.now - @@handlers_start
-  end
-  def self.resource_update_applied
-    @@num_resources_modified += 1
-  end
-  def self.report(run_status)
-    url = run_status.node['honeycomb']['api_url']
-    path = "/1/events/#{run_status.node['honeycomb']['dataset']}"
-    headers = {
-      "X-Honeycomb-Team" => run_status.node['honeycomb']['writekey'],
-      "X-Event-Time" => run_status.start_time.iso8601,
-    }
-    api_data = {
-      "node.name" => run_status.node.name,
-      "start_time" => run_status.start_time,
-      "end_time" => run_status.end_time,
-      "elapsed_time" => run_status.elapsed_time,
-      "success" => run_status.success?,
-      "exception" => run_status.exception,
-      "backtrace" => run_status.backtrace,
-      "run_id" => run_status.run_id,
-      "updated_resources" => run_status.updated_resources,
-      "converge_duration" => @@converge_duration,
-      "converge_start" => @@converge_start,
-      "handlers_duration" => @@handlers_duration,
-      "handlers_start" => @@handlers_start,
-      "num_resources_modified" => @@num_resources_modified,
-      "run_list" => run_status.node.run_list.to_s,
-    }
-    Chef::Log.debug "about to submit api data #{api_data}"
-    Chef::HTTP::SimpleJSON.new(url).post(path, api_data, headers)
+  class << self
+    attr_accessor :converge_start,
+                  :converge_duration,
+                  :handlers_start,
+                  :handlers_duration,
+                  :num_resources_modified
+
+    def num_resources_modified
+      @num_resources_modified ||= 0
+    end
+
+    def converge_started
+      self.converge_start = Time.now
+    end
+
+    def converge_completed
+      if converge_start
+        self.converge_duration = Time.now - converge_start
+      end
+    end
+
+    def handlers_started
+      self.handlers_start = Time.now
+    end
+
+    def handlers_completed
+      if handlers_start
+        self.handlers_duration = Time.now - handlers_start
+      end
+    end
+
+    def resource_update_applied
+      self.num_resources_modified += 1
+    end
+
+    def report(run_status)
+      url = run_status.node['honeycomb']['api_url']
+      path = "/1/events/#{run_status.node['honeycomb']['dataset']}"
+      headers = {
+        "X-Honeycomb-Team" => run_status.node['honeycomb']['writekey'],
+        "X-Event-Time" => run_status.start_time.iso8601,
+      }
+      api_data = {
+        "node.name" => run_status.node.name,
+        "start_time" => run_status.start_time,
+        "end_time" => run_status.end_time,
+        "elapsed_time" => run_status.elapsed_time,
+        "success" => run_status.success?,
+        "exception" => run_status.exception,
+        "backtrace" => run_status.backtrace,
+        "run_id" => run_status.run_id,
+        "updated_resources" => run_status.updated_resources,
+        "converge_duration" => converge_duration,
+        "converge_start" => converge_start,
+        "handlers_duration" => handlers_duration,
+        "handlers_start" => handlers_start,
+        "num_resources_modified" => num_resources_modified,
+        "run_list" => run_status.node.run_list.to_s,
+      }
+      Chef::Log.debug "about to submit api data #{api_data}"
+      Chef::HTTP::SimpleJSON.new(url).post(path, api_data, headers)
+    end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,4 @@ maintainer_email 'ben@honeycomb.io'
 license          'All rights reserved'
 description      'Sets up Honeycomb report handler'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
-
+version          '0.1.1'


### PR DESCRIPTION
Fixes an issue where if some of the events have not been called during the chef run it would blow up when it came time to report the data to honeycomb.
