### PR TITLE
Update handler to produce a full trace with child spans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+## Ignore .vscode stuff
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Steps to use this cookbook to report statistics to [Honeycomb](https://honeycomb
 * put your writekey in the attributes file, update dataset name if you wish
 * add the cookbook *early* in the list (first is great)
 * add the commented section from the recipes/default.rb to client.rb or other location
-** details: [https://docs.chef.io/config_rb_client.html](https://docs.chef.io/config_rb_client.html)
+** See Chef's [config.rb documentation](https://docs.chef.io/config_rb_client.html)
 
 run chef and see reports in Honeycomb!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Steps to use this cookbook to report statistics to [Honeycomb](https://honeycomb
 * put your writekey in the attributes file, update dataset name if you wish
 * add the cookbook *early* in the list (first is great)
 * add the commented section from the recipes/default.rb to client.rb or other location
-** details: https://docs.chef.io/config_rb_client.html
+** details: [https://docs.chef.io/config_rb_client.html](https://docs.chef.io/config_rb_client.html)
 
 run chef and see reports in Honeycomb!
 
@@ -18,5 +18,3 @@ will see debug output which will include the HTTP POST to Honeycomb and its
 results. Look for `DEBUG: Initiating POST` in the log. If you don't see
 anything in Honeycomb, try using this flag and look to see whether Honeycomb is
 responding with HTTP 200.
-
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,39 @@
 default['honeycomb']['writekey'] = "REPLACE_ME"
 default['honeycomb']['api_url'] = "https://api.honeycomb.io"
 default['honeycomb']['dataset'] = "chefruns"
+
+# Used to generate a link to chef-run information in Automate
+default['honeycomb']['automate_fqdn'] = "automate.example.com"
+
+# Custom node attributes you want to add as attributes to events for your query-building desires
+default['honeycomb']['tracked_attributes'] = {
+  'chef.node.random_files' => node['random_files'],
+  'chef.node.random_fail' => node['random_fail'],
+  'chef.node.audit.compliance_phase' => node['audit']['compliance_phase'],
+}
+
+######################################################################
+# Be advised that this hanlder tracks several node objects by default
+#   so you don't need to add them above.  See the list below:
+######################################################################
+# node['name']
+# node['chef_guid']
+# node['chef_packages']['chef']['version']
+# node['chef_packages']['ohai']['version']
+# node['os']
+# node['os_version']
+# node['platform']
+# node['platform_family']
+# node['platform_version']
+# node['kernel']['processor']
+# node['ipaddress']
+# node['hostname']
+# node['machinename']
+# node['fqdn']
+# node['cloud']
+# node['chef_environment']
+# node['policy_name']
+# node['policy_group']
+# node['policy_revision']
+# node['roles']
+######################################################################

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,9 +7,8 @@ default['honeycomb']['automate_fqdn'] = "automate.example.com"
 
 # Custom node attributes you want to add as attributes to events for your query-building desires
 default['honeycomb']['tracked_attributes'] = {
-  'chef.node.random_files' => node['random_files'],
-  'chef.node.random_fail' => node['random_fail'],
-  'chef.node.audit.compliance_phase' => node['audit']['compliance_phase'],
+  'chef.node.example' => node['example'],
+  'chef.node.other.example.attribute' => node['other']['example']['attribute'],
 }
 
 ######################################################################

--- a/libraries/honeycomb.rb
+++ b/libraries/honeycomb.rb
@@ -2,7 +2,7 @@ require "chef/http/simple_json"
 require "time"
 require "securerandom" unless defined?(SecureRandom)
 
-VERSION="1.0.0"
+VERSION="0.1.1"
 
 class Honeycomb
   class << self
@@ -42,15 +42,6 @@ class Honeycomb
 
     def merge_hash(hash_src, hash_dest)
       ::Chef::Mixin::DeepMerge.deep_merge!(hash_src, hash_dest)
-    end
-
-    def generate_trace_context(type)
-      case type
-      when 'trace'
-        SecureRandom.hex(16)
-      when 'span'
-        SecureRandom.hex(8)
-      end
     end
 
     def generate_span(run_status, **args)
@@ -94,7 +85,7 @@ class Honeycomb
       merge_hash(resource_data, span_data)
 
       if node_exists == true
-        h = {
+        node_data = {
           'chef.node.name' => run_status.node.name,
           'chef.node.guid' => run_status.node['chef_guid'],
           'chef.node.chef_version' => run_status.node['chef_packages']['chef']['version'],
@@ -115,52 +106,47 @@ class Honeycomb
           'chef.policy_group' => run_status.node['policy_group'],
           'chef.policy_revision' => run_status.node['policy_revision'],
           'chef.roles' => run_status.node['roles'],
-          # 'chef.complete_node' => ::Chef::DSL::RenderHelpers::render_json(run_status.node),
         }
 
-        merge_hash(h, span_data)
+        merge_hash(node_data, span_data)
 
-        n = run_status.node['honeycomb']['tracked_attributes']
-        merge_hash(n, span_data)
+        node_attributes = run_status.node['honeycomb']['tracked_attributes']
+        merge_hash(node_attributes, span_data)
       end
 
       #########################################
       # Define the parent_id if not the root span
       #########################################
       if args.key?(:parent_id)
-        h = {
-          'meta.span_type' => 'child',
-        }
-        merge_hash(h, span_data)
+        span_data['meta.span_type'] = 'child'
       else
-        h = { 'meta.span_type' => 'root' }
-        merge_hash(h, span_data)
+        span_data['meta.span_type'] = 'root'
       end
 
       #########################################
       # Span Duration Values
       #########################################
       if args.key?(:duration_ms)
-        h = {
+        timing_data = {
           'duration_ms' => args[:duration_ms],
           'start_time'  => args[:start_time],
           'end_time'    => args[:end_time],
         }
-        merge_hash(h, span_data)
+        merge_hash(timing_data, span_data)
       end
 
       #########################################
       # These values are used by the root span
       #########################################
       if args[:end_run] == true
-        h = {
+        end_run_data = {
           'start_time' => run_status.start_time.iso8601(fraction_digits = 3),
           'end_time' => run_status.end_time.iso8601(fraction_digits = 3),
           'duration_ms' => (run_status.elapsed_time * 1000.0),
           'success' => run_status.success?,
         }
 
-        merge_hash(h, span_data)
+        merge_hash(end_run_data, span_data)
 
         #########################################
         # If run fails, make it a failure
@@ -169,28 +155,28 @@ class Honeycomb
           run_backtrace = nil
           run_backtrace = run_status.backtrace.join("\n") unless run_status.backtrace.nil?
 
-          n = {
+          error_data = {
             "error" => true,
             "exception" => run_status.exception,
             "backtrace" => run_backtrace,
           }
 
-          merge_hash(n, span_data)
+          merge_hash(error_data, span_data)
         end
 
         #########################################
         # If sending to Automate, generate link to client run
         #########################################
         unless run_status.node['honeycomb']['automate_fqdn'].nil?
-          am8_url = "https://#{run_status.node['honeycomb']['automate_fqdn']}"
-          am8_url += "/infrastructure/client-runs/#{run_status.node['chef_guid']}"
-          am8_url += "/runs/#{run_status.run_id}"
+          automate_run_url = "https://#{run_status.node['honeycomb']['automate_fqdn']}"
+          automate_run_url += "/infrastructure/client-runs/#{run_status.node['chef_guid']}"
+          automate_run_url += "/runs/#{run_status.run_id}"
           
-          h = {
-            'automate_run_link' => am8_url,
+          automate_data = {
+            'chef.automate_run_link' => automate_run_url,
           }
 
-          merge_hash(h, span_data)
+          merge_hash(automate_data, span_data)
         end
       end
 
@@ -199,8 +185,6 @@ class Honeycomb
       #########################################
       return_data = Hash.new
       return_data['time'] = args[:start_time] ||= run_status.start_time.iso8601(fraction_digits = 3)
-      # return_data['start_time'] = run_status.methods.include?(:start_time) ? run_status.start_time : args[:start_time]
-      # return_data['end_time'] = run_status.methods.include?(:end_time) ? run_status.end_time : args[:end_time]
       return_data['data'] = span_data
       return_data
     end

--- a/libraries/honeycomb.rb
+++ b/libraries/honeycomb.rb
@@ -1,7 +1,8 @@
 require "chef/http/simple_json"
 require "time"
+require "securerandom" unless defined?(SecureRandom)
 
-VERSION="0.1.1"
+VERSION="1.0.0"
 
 class Honeycomb
   class << self
@@ -39,32 +40,158 @@ class Honeycomb
       self.num_resources_modified += 1
     end
 
-    def report(run_status)
+    def merge_hash(hash_src, hash_dest)
+      ::Chef::Mixin::DeepMerge.deep_merge!(hash_src, hash_dest)
+    end
+
+    def generate_trace_context(type)
+      case type
+      when 'trace'
+        SecureRandom.hex(16)
+      when 'span'
+        SecureRandom.hex(8)
+      end
+    end
+
+    def generate_span(run_status, **args)
+      run_id = run_status.methods.include?(:run_id) ? run_status.run_id : nil
+      node_exists = run_status.methods.include?(:node) ? true : false
+      #########################################
+      # These values go in every span
+      #########################################
+      span_data = {
+        'trace.trace_id' => args[:trace_id],
+        'trace.span_id' => args[:span_id],
+        'trace.parent_id' => args[:parent_id] ||= nil,
+        'service.name' => 'chef',
+        'name' => args[:event] ||= 'chef-client',
+        'run_id' => run_id,
+        'chef.handler_count' => args[:handler_count],
+        'chef.resource_name' => args[:resource_name],
+        'chef.resource_recipe' => args[:resource_recipe],
+        'chef.resource_cookbook' => args[:resource_cookbook],
+        'chef.resource_action' => args[:resource_action],
+      }
+
+      if node_exists == true
+        h = {
+          'chef.node.name' => run_status.node.name,
+          'chef.node.guid' => run_status.node['chef_guid'],
+          'chef.node.chef_version' => run_status.node['chef_packages']['chef']['version'],
+          'chef.node.ohai_version' => run_status.node['chef_packages']['ohai']['version'],
+          'chef.node.os' => run_status.node['os'],
+          'chef.node.os.version' => run_status.node['os_version'],
+          'chef.node.platform' => run_status.node['platform'],
+          'chef.node.platform_family' => run_status.node['platform_family'],
+          'chef.node.platform_version' => run_status.node['platform_version'],
+          'chef.node.kernel.processor' => run_status.node['kernel']['processor'],
+          'chef.node.ipaddress' => run_status.node['ipaddress'],
+          'chef.node.hostname' => run_status.node['hostname'],
+          'chef.node.machinename' => run_status.node['machinename'],
+          'chef.node.fqdn' => run_status.node['fqdn'],
+          'chef.node.cloud' => run_status.node['cloud'],
+          'chef.environment' => run_status.node['chef_environment'],
+          'chef.policy_name' => run_status.node['policy_name'],
+          'chef.policy_group' => run_status.node['policy_group'],
+          'chef.policy_revision' => run_status.node['policy_revision'],
+          'chef.roles' => run_status.node['roles'],
+          'node.random_fail' => run_status.node['random_fail'],
+          # 'chef.complete_node' => ::Chef::DSL::RenderHelpers::render_json(run_status.node),
+        }
+
+        merge_hash(h, span_data)
+      end
+
+      #########################################
+      # Define the parent_id if not the root span
+      #########################################
+      if args.key?(:parent_id)
+        h = {
+          'meta.span_type' => 'child',
+        }
+        merge_hash(h, span_data)
+      else
+        h = { 'meta.span_type' => 'root' }
+        merge_hash(h, span_data)
+      end
+
+      #########################################
+      # Span Duration Values
+      #########################################
+      if args.key?(:duration_ms)
+        h = {
+          'duration_ms' => args[:duration_ms],
+          'start_time'  => args[:start_time],
+          'end_time'    => args[:end_time],
+        }
+        merge_hash(h, span_data)
+      end
+
+      #########################################
+      # These values are used by the root span
+      #########################################
+      if args[:end_run] == true
+        h = {
+          'start_time' => run_status.start_time.iso8601(fraction_digits = 3),
+          'end_time' => run_status.end_time.iso8601(fraction_digits = 3),
+          'duration_ms' => (run_status.elapsed_time * 1000.0),
+          'success' => run_status.success?,
+        }
+
+        merge_hash(h, span_data)
+
+        #########################################
+        # If run fails, make it a failure
+        #########################################
+        unless run_status.success? || args[:error] == false
+          run_backtrace = nil
+          run_backtrace = run_status.backtrace.join("\n") unless run_status.backtrace.nil?
+
+          n = {
+            "error" => true,
+            "exception" => run_status.exception,
+            "backtrace" => run_backtrace,
+          }
+
+          merge_hash(n, span_data)
+        end
+
+        #########################################
+        # If sending to Automate, generate link to client run
+        #########################################
+        unless run_status.node['honeycomb']['automate_fqdn'].nil?
+          am8_url = "https://#{run_status.node['honeycomb']['automate_fqdn']}"
+          am8_url += "/infrastructure/client-runs/#{run_status.node['chef_guid']}"
+          am8_url += "/runs/#{run_status.run_id}"
+          
+          h = {
+            'automate_run_link' => am8_url,
+          }
+
+          merge_hash(h, span_data)
+        end
+      end
+
+      #########################################
+      # Return the completed span data
+      #########################################
+      return_data = Hash.new
+      return_data['time'] = args[:start_time] ||= run_status.start_time.iso8601(fraction_digits = 3)
+      # return_data['start_time'] = run_status.methods.include?(:start_time) ? run_status.start_time : args[:start_time]
+      # return_data['end_time'] = run_status.methods.include?(:end_time) ? run_status.end_time : args[:end_time]
+      return_data['data'] = span_data
+      return_data
+    end
+
+    def report(run_status, trace_batch)
       url = run_status.node['honeycomb']['api_url']
-      path = "/1/events/#{run_status.node['honeycomb']['dataset']}"
+      path = "/1/batch/#{run_status.node['honeycomb']['dataset']}"
       headers = {
         "X-Honeycomb-Team" => run_status.node['honeycomb']['writekey'],
-        "X-Event-Time" => run_status.start_time.iso8601,
       }
-      api_data = {
-        "node.name" => run_status.node.name,
-        "start_time" => run_status.start_time,
-        "end_time" => run_status.end_time,
-        "elapsed_time" => run_status.elapsed_time,
-        "success" => run_status.success?,
-        "exception" => run_status.exception,
-        "backtrace" => run_status.backtrace,
-        "run_id" => run_status.run_id,
-        "updated_resources" => run_status.updated_resources,
-        "converge_duration" => converge_duration,
-        "converge_start" => converge_start,
-        "handlers_duration" => handlers_duration,
-        "handlers_start" => handlers_start,
-        "num_resources_modified" => num_resources_modified,
-        "run_list" => run_status.node.run_list.to_s,
-      }
-      Chef::Log.debug "about to submit api data #{api_data}"
-      Chef::HTTP::SimpleJSON.new(url).post(path, api_data, headers)
+
+      Chef::Log.info "Sending trace to Honeycomb API at #{url}#{path}"
+      Chef::HTTP::SimpleJSON.new(url).post(path, trace_batch, headers)
     end
   end
 end

--- a/libraries/honeycomb.rb
+++ b/libraries/honeycomb.rb
@@ -65,13 +65,33 @@ class Honeycomb
         'trace.parent_id' => args[:parent_id] ||= nil,
         'service.name' => 'chef',
         'name' => args[:event] ||= 'chef-client',
-        'run_id' => run_id,
-        'chef.handler_count' => args[:handler_count],
-        'chef.resource_name' => args[:resource_name],
-        'chef.resource_recipe' => args[:resource_recipe],
-        'chef.resource_cookbook' => args[:resource_cookbook],
-        'chef.resource_action' => args[:resource_action],
+        'run_id' => run_id,        
       }
+
+      config_data = {
+        'chef.config.server' => Chef::Config[:chef_server_url],
+        'chef.config.fips' => Chef::Config[:fips],
+        'chef.config.data_collector.server_url' => Chef::Config[:data_collector][:server_url],
+        'chef.config.http_proxy' => Chef::Config[:http_proxy],
+        'chef.config.https_proxy' => Chef::Config[:https_proxy],
+        'chef.config.ftp_proxy' => Chef::Config[:ftp_proxy],
+        'chef.config.no_proxy' => Chef::Config[:no_proxy],
+        'chef.config.rubygems_url' => Chef::Config[:rubygems_url],
+        'chef.config.policy_name' => Chef::Config[:policy_name],
+        'chef.config.policy_group' => Chef::Config[:policy_grid],
+        'chef.config.named_run_list' => Chef::Config[:named_run_list],
+      }
+      merge_hash(config_data, span_data)
+
+      resource_data = {
+        'chef.resource_name' => args[:resource_name],
+        'chef.resource_type' => args[:resource_type],
+        'chef.recipe' => args[:recipe],
+        'chef.cookbook' => args[:cookbook],
+        'chef.resource_action' => args[:resource_action],
+        'chef.resource_status' => args[:resource_status],
+      }
+      merge_hash(resource_data, span_data)
 
       if node_exists == true
         h = {
@@ -95,11 +115,13 @@ class Honeycomb
           'chef.policy_group' => run_status.node['policy_group'],
           'chef.policy_revision' => run_status.node['policy_revision'],
           'chef.roles' => run_status.node['roles'],
-          'node.random_fail' => run_status.node['random_fail'],
           # 'chef.complete_node' => ::Chef::DSL::RenderHelpers::render_json(run_status.node),
         }
 
         merge_hash(h, span_data)
+
+        n = run_status.node['honeycomb']['tracked_attributes']
+        merge_hash(n, span_data)
       end
 
       #########################################

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,8 +9,9 @@ Chef.event_handler do
   root_span_id = SecureRandom.hex(8)
   compile_span_id = SecureRandom.hex(8)
   converge_span_id = SecureRandom.hex(8)
-  # compliance_span_id = SecureRandom.hex(8)
+
   trace_batch = []
+
   comp_start = Time.parse(Time.now.iso8601(fraction_digits = 3))
   @conv_start = Time.parse(Time.now.iso8601(fraction_digits = 3))
   Chef::Client.when_run_starts {|run_status| @handler.instance_variable_set(:@run_status, run_status) }
@@ -284,7 +285,6 @@ Chef.event_handler do
     trace_batch << handler_span
 
     ::Honeycomb.report(@run_status, trace_batch)
-    # Chef::Handler::JsonFile(@run_status, path: '/tmp/reports')
   end
   on :run_failed do
     root_trace = ::Honeycomb.generate_span(@run_status, trace_id: trace_id, span_id: root_span_id, end_run: true)
@@ -321,7 +321,6 @@ Chef.event_handler do
     trace_batch << handler_span
 
     ::Honeycomb.report(@run_status, trace_batch)
-    # Chef::Handler::JsonFile(@run_status, path: '/tmp/reports')
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,11 +1,299 @@
+###############################################################
+# Adding this recipe to the runlist of your node or policyfile
+#   should work well to get you nice waterfall representations
+#   of your Chef-Client runs
+###############################################################
+
 Chef.event_handler do
+  trace_id = SecureRandom.hex(16)
+  root_span_id = SecureRandom.hex(8)
+  compile_span_id = SecureRandom.hex(8)
+  converge_span_id = SecureRandom.hex(8)
+  # compliance_span_id = SecureRandom.hex(8)
+  trace_batch = []
+  comp_start = Time.parse(Time.now.iso8601(fraction_digits = 3))
+  @conv_start = Time.parse(Time.now.iso8601(fraction_digits = 3))
+  Chef::Client.when_run_starts {|run_status| @handler.instance_variable_set(:@run_status, run_status) }
+
+  on :cookbook_compilation_complete do
+    |run_context|
+    @comp_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+  end
+  on :converge_start do
+    @conv_start = Time.parse(Time.now.iso8601(fraction_digits = 3))
+    @current_cookbook_name = nil
+    @current_recipe_name = nil
+  end
+  on :converge_complete do
+    recipe_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+
+    duration = recipe_stop - @recipe_start
+    duration_ms = duration * 1000
+    recipe_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: @current_recipe_span,
+      parent_id: @current_cookbook_span,
+      duration_ms: duration_ms,
+      start_time: @recipe_start.iso8601(fraction_digits = 3),
+      end_time: recipe_stop.iso8601(fraction_digits = 3),
+      event: "recipe: #{@current_recipe_name}",
+    )
+
+    trace_batch << recipe_span
+
+    cookbook_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+
+    duration = cookbook_stop - @cookbook_start
+    duration_ms = duration * 1000
+    cookbook_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: @current_cookbook_span,
+      parent_id: converge_span_id,
+      duration_ms: duration_ms,
+      start_time: @cookbook_start.iso8601(fraction_digits = 3),
+      end_time: cookbook_stop.iso8601(fraction_digits = 3),
+      event: "cookbook: #{@current_cookbook_name}",
+    )
+
+    trace_batch << cookbook_span
+
+    @conv_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+    conv_duration = @conv_stop - @conv_start
+    conv_duration_ms = conv_duration * 1000
+
+    converge_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: converge_span_id,
+      parent_id: root_span_id,
+      duration_ms: conv_duration_ms,
+      start_time: @conv_start.iso8601(fraction_digits = 3),
+      end_time: @conv_stop.iso8601(fraction_digits = 3),
+      event: 'converge',
+    )
+    trace_batch << converge_span
+  end
+  on :converge_failed do
+    |exception|
+    recipe_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+
+    duration = recipe_stop - @recipe_start
+    duration_ms = duration * 1000
+    recipe_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: @current_recipe_span,
+      parent_id: @current_cookbook_span,
+      duration_ms: duration_ms,
+      start_time: @recipe_start.iso8601(fraction_digits = 3),
+      end_time: recipe_stop.iso8601(fraction_digits = 3),
+      event: "recipe: #{@current_recipe_name}",
+      error: true,
+      exception: exception,
+    )
+
+    trace_batch << recipe_span
+
+    cookbook_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+
+    duration = cookbook_stop - @cookbook_start
+    duration_ms = duration * 1000
+    cookbook_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: @current_cookbook_span,
+      parent_id: converge_span_id,
+      duration_ms: duration_ms,
+      start_time: @cookbook_start.iso8601(fraction_digits = 3),
+      end_time: cookbook_stop.iso8601(fraction_digits = 3),
+      event: "cookbook: #{@current_cookbook_name}",
+      error: true,
+      exception: exception,
+    )
+
+    trace_batch << cookbook_span
+
+    @conv_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+    conv_duration = @conv_stop - @conv_start
+    conv_duration_ms = conv_duration * 1000
+
+    converge_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: converge_span_id,
+      parent_id: root_span_id,
+      duration_ms: conv_duration_ms,
+      start_time: @conv_start.iso8601(fraction_digits = 3),
+      end_time: @conv_stop.iso8601(fraction_digits = 3),
+      error: true,
+      exception: exception,
+      event: 'converge',
+    )
+    trace_batch << converge_span
+  end
+  on :resource_completed do
+    |resource|
+    resource_stop = Time.parse(Time.now.iso8601(fraction_digits = 3))
+    duration_ms = resource.elapsed_time * 1000
+    resource_start = resource_stop - resource.elapsed_time
+
+    if @current_recipe_name.nil?
+      @recipe_start = @conv_start
+      @current_recipe_name = resource.recipe_name
+      @current_recipe_span = SecureRandom.hex(8)
+    end
+
+    if @current_recipe_name != resource.recipe_name
+      recipe_stop = Time.parse(resource_start.iso8601(fraction_digits = 3))
+
+      duration = recipe_stop - @recipe_start
+      duration_ms = duration * 1000
+
+      recipe_span = ::Honeycomb.generate_span(
+        @run_status,
+        trace_id: trace_id,
+        span_id: @current_recipe_span,
+        parent_id: @current_cookbook_span,
+        duration_ms: duration_ms,
+        start_time: @recipe_start.iso8601(fraction_digits = 3),
+        end_time: recipe_stop.iso8601(fraction_digits = 3),
+        event: "recipe: #{@current_recipe_name}",
+      )
+
+      trace_batch << recipe_span
+
+      @recipe_start = recipe_stop
+      @current_recipe_name = resource.recipe_name
+      @current_recipe_span = SecureRandom.hex(8)
+    end
+
+    if @current_cookbook_name.nil?
+      @cookbook_start = @conv_start
+      @current_cookbook_name = resource.cookbook_name
+      @current_cookbook_span = SecureRandom.hex(8)
+    end
+
+    if @current_cookbook_name != resource.cookbook_name
+      cookbook_stop = Time.parse(resource_start.iso8601(fraction_digits = 3))
+
+      duration = cookbook_stop - @cookbook_start
+      duration_ms = duration * 1000
+      cookbook_span = ::Honeycomb.generate_span(
+        @run_status,
+        trace_id: trace_id,
+        span_id: @current_cookbook_span,
+        parent_id: converge_span_id,
+        duration_ms: duration_ms,
+        start_time: @cookbook_start.iso8601(fraction_digits = 3),
+        end_time: cookbook_stop.iso8601(fraction_digits = 3),
+        event: "cookbook: #{@current_cookbook_name}",
+      )
+
+      trace_batch << cookbook_span
+
+      @cookbook_start = cookbook_stop
+      @current_cookbook_name = resource.cookbook_name
+      @current_cookbook_span = SecureRandom.hex(8)
+    end
+    span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: SecureRandom.hex(8),
+      parent_id: @current_recipe_span,
+      duration_ms: resource.elapsed_time * 1000,
+      start_time: resource_start.iso8601(fraction_digits =3),
+      end_time: resource_stop.iso8601(fraction_digits = 3),
+      resource_name: resource.to_s,
+      resource_recipe: resource.recipe_name,
+      resource_cookbook: resource.cookbook_name,
+      resource_action: resource.action,
+      event: resource.to_s,
+    )
+    trace_batch << span
+  end
+
   Chef::Client.when_run_completes_successfully {|run_status| @handler.instance_variable_set(:@run_status, run_status) }
   Chef::Client.when_run_fails {|run_status| @handler.instance_variable_set(:@run_status, run_status) }
   on :run_completed do
-    ::Honeycomb.report(@run_status)
+    root_trace = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: root_span_id,
+      end_run: true
+    )
+    trace_batch << root_trace
+
+    comp_duration = @comp_stop - (Time.parse(@run_status.start_time.iso8601(fraction_digits = 3)))
+    comp_duration_ms = comp_duration * 1000
+    compile_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: compile_span_id,
+      parent_id: root_span_id,
+      duration_ms: comp_duration_ms,
+      start_time: @run_status.start_time.iso8601(fraction_digits = 3),
+      end_time: @comp_stop.iso8601(fraction_digits = 3),
+      event: 'compile',
+    )
+    trace_batch << compile_span
+
+    handler_start = @conv_stop
+    handler_stop = Time.parse(@run_status.end_time.iso8601(fraction_digits = 3))
+    handler_duration = handler_stop - handler_start
+    handler_duration_ms = handler_duration * 1000
+    handler_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: SecureRandom.hex(8),
+      parent_id: root_span_id,
+      duration_ms: handler_duration_ms,
+      start_time: handler_start.iso8601(fraction_digits = 3),
+      end_time: handler_stop.iso8601(fraction_digits = 3),
+      event: 'running-handlers'
+    )
+    trace_batch << handler_span
+
+    ::Honeycomb.report(@run_status, trace_batch)
+    # Chef::Handler::JsonFile(@run_status, path: '/tmp/reports')
   end
   on :run_failed do
-    ::Honeycomb.report(@run_status)
+    root_trace = ::Honeycomb.generate_span(@run_status, trace_id: trace_id, span_id: root_span_id, end_run: true)
+    trace_batch << root_trace
+
+    comp_duration = @comp_stop - (Time.parse(@run_status.start_time.iso8601(fraction_digits =3)))
+    comp_duration_ms = comp_duration * 1000
+    compile_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: compile_span_id,
+      parent_id: root_span_id,
+      duration_ms: comp_duration_ms,
+      start_time: @run_status.start_time.iso8601(fraction_digits = 3),
+      end_time: @comp_stop.iso8601(fraction_digits = 3),
+      event: 'compile',
+    )
+    trace_batch << compile_span
+
+    handler_start = @conv_stop
+    handler_stop = Time.parse(@run_status.end_time.iso8601(fraction_digits = 3))
+    handler_duration = handler_stop - handler_start
+    handler_duration_ms = handler_duration * 1000
+    handler_span = ::Honeycomb.generate_span(
+      @run_status,
+      trace_id: trace_id,
+      span_id: SecureRandom.hex(8),
+      parent_id: root_span_id,
+      duration_ms: handler_duration_ms,
+      start_time: handler_start.iso8601(fraction_digits = 3),
+      end_time: handler_stop.iso8601(fraction_digits = 3),
+      event: "running-handlers"
+    )
+    trace_batch << handler_span
+
+    ::Honeycomb.report(@run_status, trace_batch)
+    # Chef::Handler::JsonFile(@run_status, path: '/tmp/reports')
   end
 end
 


### PR DESCRIPTION
## Which problem is this PR solving?

The current version of the handler does not produce what Honeycomb recognizes as a trace, so there is no waterfall view of processes, access to use the node object in queries, and very minimal bubble up capabilities.

## Short description of the changes

This updates the product to be a full trace, where the compile, converge, and handler phases are all shown as child spans, and the converge phase is broken down into spans per cookbook, recipe, and resource.

All objects have access to a subset of the node object that make bubble-up and querying more interesting, and users are provided with a mechanism to ensure that node attributes/objects that they care about can be included in that data as well.

## Notes

There's some funky code to make this work as a handler that's part of a cookbook, but it does. If I were committing this as something I wanted to be part of Chef itself, there would be cleaner ways to do certain things.

## Resulting Images

Here are some screen captures of this handler in action in waterfall mode, query + heatmap, and bubble-up:
![image (4)](https://user-images.githubusercontent.com/162021/187552015-8a315acf-fb29-40f2-8451-386bf450ca02.png)
![image (3)](https://user-images.githubusercontent.com/162021/187552016-f9a38f73-eb4f-4d7f-9a77-82970c966231.png)
![image (2)](https://user-images.githubusercontent.com/162021/187552020-04989c12-518c-4cc2-8d60-2928807656e9.png)
![image (1)](https://user-images.githubusercontent.com/162021/187552022-db3406f9-37ee-42a4-85a4-ecb148efc5df.png)
